### PR TITLE
[Step4/blog simple] 프로필 링크 블로그 서버를 추가 / URL 단축 구조를 수정합니다.

### DIFF
--- a/blog-api/README.md
+++ b/blog-api/README.md
@@ -55,9 +55,9 @@ classDiagram
     }
     
     class BlockProfile {
-        +String mainText
-        +String subText
-        +String profileImage
+        +MainBaseText main
+        +SubBaseText sub
+        +Image profileImage
     }
     
     class BlockLink {

--- a/blog-api/README.md
+++ b/blog-api/README.md
@@ -1,0 +1,81 @@
+## Step 4. Simple Blog
+
+프로필 링크 페이지를 만듭니다.  
+블럭들을 만들고, 수정하고, 삭제합니다.  
+한 페이지에 프로필 블럭, 텍스트 블럭, 미디어 블럭, 링크 블럭, SNS 블럭을 편집합니다.  
+
+
+## 실행하는 법
+```bash
+$ ./gradlew clean build
+$  java -jar blog-api/build/libs/blog-api-XXX.jar
+```
+
+## IDE에서 Lombok 어노테이션 처리 활성화
+
+IntelliJ IDE 에서 어노테이션 처리 활성화해야 Lombok 플러그인이 동작합니다.
+
+![스크린샷 2023-12-11 오전 4 03 49](https://github.com/kor-Chipmunk/ProfileLinkService/assets/16275188/5e1a4473-c37b-4b2b-ba15-2bfea0519ccc)
+
+
+## 시퀀스 다이어그램
+
+```mermaid
+sequenceDiagram
+    User->>+Blog Server: 페이지 생성 요청
+    Blog Server-->>-User: 페이지 응답
+    User->>+Blog Server: 페이지 수정 요청
+    Blog Server-->>-User: 페이지 응답
+```
+
+## 아키텍처
+
+![스크린샷 2023-12-13 오전 7 39 17](https://github.com/kor-Chipmunk/ProfileLinkService/assets/16275188/66ffc1be-47bc-4a31-948c-ee79c8c699f7)
+
+
+## Domain Class DIagram
+
+```mermaid
+classDiagram
+    Block <|-- BlockProfile
+    Block <|-- BlockLink
+    Block <|-- BlockText
+    Block <|-- BlockMedia
+    Block <|-- BlockSNSConnection
+    
+    class Page {
+        +MainBaseText name;
+        +BlockProfile profile;
+        +List<Block> blocks;
+    }
+
+    class Block {
+    }
+    
+    class BlockProfile {
+        +String mainText
+        +String subText
+        +String profileImage
+    }
+    
+    class BlockLink {
+        +TitleBaseText title
+        +Link link
+        +Image image
+    }
+    
+    class BlockText {
+        +TitleBaseText title
+        +ContentBaseText content
+    }
+    
+    class BlockMedia {
+        +TitleBaseText title;
+        +Link link
+    }
+    
+    class BlockSNSConnection {
+        +InstagramText instagram
+        +TelephoneText telephone
+    }
+```

--- a/blog-api/README.md
+++ b/blog-api/README.md
@@ -30,7 +30,7 @@ sequenceDiagram
 
 ## 아키텍처
 
-![스크린샷 2023-12-13 오전 7 39 17](https://github.com/kor-Chipmunk/ProfileLinkService/assets/16275188/66ffc1be-47bc-4a31-948c-ee79c8c699f7)
+![스크린샷 2024-01-02 오후 5 06 16](https://github.com/kor-Chipmunk/ProfileLinkService/assets/16275188/103586cb-d761-4c41-86dc-f92fbbfa9729)
 
 
 ## Domain Class DIagram
@@ -42,6 +42,8 @@ classDiagram
     Block <|-- BlockText
     Block <|-- BlockMedia
     Block <|-- BlockSNSConnection
+
+    Page <-- Block
     
     class Page {
         +MainBaseText name;

--- a/blog-api/build.gradle
+++ b/blog-api/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+    testImplementation "org.testcontainers:testcontainers:1.19.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.3"
+    testImplementation "org.testcontainers:mongodb"
+}

--- a/blog-api/docker-compose.yml
+++ b/blog-api/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.8"
+
+services:
+
+  mongo:
+    image: mongo
+    container_name: blog-mongo
+    restart: always
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: chipmunk
+      MONGO_INITDB_ROOT_PASSWORD: JMTpdsu8YkLEXBW4RA
+      MONGO_INITDB_DATABASE: blog
+    volumes:
+      - mongodbdata:/data/db:cached
+      - ./init-mongo.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 27000:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: chipmunk
+      ME_CONFIG_MONGODB_ADMINPASSWORD: JMTpdsu8YkLEXBW4RA
+      ME_CONFIG_MONGODB_SERVER: blog-mongo
+      ME_CONFIG_BASICAUTH_USERNAME: chipmunk-admin
+      ME_CONFIG_BASICAUTH_PASSWORD: g2+u*8XG%^xKT=-SzDMfbZ
+
+volumes:
+  mongodbdata:
+    driver: local

--- a/blog-api/init-mongo.js
+++ b/blog-api/init-mongo.js
@@ -1,0 +1,14 @@
+db.createCollection("blog");
+
+db.createUser(
+    {
+        user: "chipmunk",
+        pwd: "JMTpdsu8YkLEXBW4RA",
+        roles: [
+            {
+                role: "readWrite",
+                db: "blog"
+            }
+        ]
+    }
+);

--- a/blog-api/src/main/java/com/smilegate/blog/BlogApplication.java
+++ b/blog-api/src/main/java/com/smilegate/blog/BlogApplication.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BlogApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BlogApplication.class, args);
+    }
+
+}

--- a/blog-api/src/main/java/com/smilegate/blog/config/CustomMongoTypeMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/config/CustomMongoTypeMapper.java
@@ -1,0 +1,12 @@
+package com.smilegate.blog.config;
+
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+
+public class CustomMongoTypeMapper extends DefaultMongoTypeMapper {
+
+    private static final String TYPE_KEY = "type";
+
+    public CustomMongoTypeMapper() {
+        super(TYPE_KEY);
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/config/MongoAuditingConfiguration.java
+++ b/blog-api/src/main/java/com/smilegate/blog/config/MongoAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.smilegate.blog.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoAuditingConfiguration {
+}

--- a/blog-api/src/main/java/com/smilegate/blog/config/MongoConfiguration.java
+++ b/blog-api/src/main/java/com/smilegate/blog/config/MongoConfiguration.java
@@ -1,0 +1,45 @@
+package com.smilegate.blog.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.convert.DbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+@Configuration
+@RequiredArgsConstructor
+public class MongoConfiguration extends AbstractMongoClientConfiguration {
+
+    private final Environment env;
+
+    @Override
+    protected String getDatabaseName() {
+        return "blog";
+    }
+
+    @Override
+    protected void configureClientSettings(Builder builder) {
+        String uri = env.getProperty("spring.data.mongodb.uri");
+        builder.applyConnectionString(new ConnectionString(uri));
+    }
+
+    @Override
+    public MappingMongoConverter mappingMongoConverter(
+            MongoDatabaseFactory databaseFactory
+            , MongoCustomConversions customConversions
+            , MongoMappingContext mappingContext
+    ) {
+        DbRefResolver resolver = new DefaultDbRefResolver(databaseFactory);
+        MappingMongoConverter converter = new MappingMongoConverter(resolver, mappingContext);
+        converter.setTypeMapper(new CustomMongoTypeMapper());
+        return converter;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/PageController.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/PageController.java
@@ -1,0 +1,69 @@
+package com.smilegate.blog.controller;
+
+import com.smilegate.blog.controller.dto.CreatePageRequestDTO;
+import com.smilegate.blog.controller.dto.CreatePageResponseDTO;
+import com.smilegate.blog.controller.dto.ReadPageResponseDTO;
+import com.smilegate.blog.controller.dto.UpdatePageRequestDTO;
+import com.smilegate.blog.controller.mapper.CreatePageResponseMapper;
+import com.smilegate.blog.controller.mapper.ReadPageResponseMapper;
+import com.smilegate.blog.service.PageService;
+import com.smilegate.blog.service.dto.CreatePageRequest;
+import com.smilegate.blog.service.dto.PageResponse;
+import com.smilegate.blog.service.dto.UpdatePageRequest;
+import com.smilegate.blog.service.mapper.CreatePageRequestMapper;
+import com.smilegate.blog.service.mapper.UpdatePageRequestMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("pages")
+@RequiredArgsConstructor
+public class PageController {
+    private final PageService service;
+
+    @PostMapping
+    public ResponseEntity<CreatePageResponseDTO> createPage(@RequestBody CreatePageRequestDTO request) {
+        CreatePageRequest createPageRequestDTO = CreatePageRequestMapper.create(request.name());
+        PageResponse pageResponse = service.createPage(createPageRequestDTO);
+        CreatePageResponseDTO response = CreatePageResponseMapper.create(pageResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{pageId}")
+    public ResponseEntity<ReadPageResponseDTO> readPage(@PathVariable("pageId") String pageId) {
+        PageResponse pageResponse = service.readPage(pageId);
+        ReadPageResponseDTO response = ReadPageResponseMapper.create(pageResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{pageId}")
+    public ResponseEntity<ReadPageResponseDTO> updatePage(
+            @PathVariable("pageId") String pageId
+            , @RequestBody UpdatePageRequestDTO request
+    ) {
+        UpdatePageRequest updatePageDTO = UpdatePageRequestMapper.create(
+                pageId
+                , request.name()
+                , request.profile()
+                , request.blocks()
+        );
+        PageResponse pageResponse = service.updatePage(updatePageDTO);
+        ReadPageResponseDTO response = ReadPageResponseMapper.create(pageResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{pageId}")
+    public ResponseEntity<ReadPageResponseDTO> deletePage(@PathVariable("pageId") String pageId) {
+        PageResponse pageResponse = service.deletePage(pageId);
+        ReadPageResponseDTO response = ReadPageResponseMapper.create(pageResponse);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/CreatePageRequestDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/CreatePageRequestDTO.java
@@ -1,0 +1,7 @@
+package com.smilegate.blog.controller.dto;
+
+public record CreatePageRequestDTO(
+        String name
+) {
+
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/CreatePageResponseDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/CreatePageResponseDTO.java
@@ -1,0 +1,8 @@
+package com.smilegate.blog.controller.dto;
+
+public record CreatePageResponseDTO(
+        String id
+        , String name
+) {
+
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/ReadPageResponseDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/ReadPageResponseDTO.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.controller.dto;
+
+import com.smilegate.blog.controller.dto.entity.BlockDTO;
+import com.smilegate.blog.controller.dto.entity.BlockProfileDTO;
+import java.util.List;
+
+public record ReadPageResponseDTO(
+        String id
+        , String name
+        , BlockProfileDTO profile
+        , List<BlockDTO> blocks
+) {
+
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/UpdatePageRequestDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/UpdatePageRequestDTO.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog.controller.dto;
+
+import com.smilegate.blog.controller.dto.entity.BlockDTO;
+import com.smilegate.blog.controller.dto.entity.BlockProfileDTO;
+import java.util.List;
+
+public record UpdatePageRequestDTO(
+        String name
+        , BlockProfileDTO profile
+        , List<BlockDTO> blocks
+) {
+
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/UpdatePageResponseDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/UpdatePageResponseDTO.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.controller.dto;
+
+import com.smilegate.blog.controller.dto.entity.BlockDTO;
+import com.smilegate.blog.controller.dto.entity.BlockProfileDTO;
+import java.util.List;
+
+public record UpdatePageResponseDTO(
+        String id
+        , String name
+        , BlockProfileDTO profile
+        , List<BlockDTO> blocks
+) {
+
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockDTO.java
@@ -1,0 +1,19 @@
+package com.smilegate.blog.controller.dto.entity;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonSubTypes(
+        {
+                @JsonSubTypes.Type(value = BlockLinkDTO.class, name = "link")
+                , @JsonSubTypes.Type(value = BlockMediaDTO.class, name = "media")
+                , @JsonSubTypes.Type(value = BlockProfileDTO.class, name = "profile")
+                , @JsonSubTypes.Type(value = BlockSNSConnectionDTO.class, name = "sns")
+                , @JsonSubTypes.Type(value = BlockTextDTO.class, name = "text")
+        }
+)
+public abstract class BlockDTO {
+
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockLinkDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockLinkDTO.java
@@ -1,0 +1,12 @@
+package com.smilegate.blog.controller.dto.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BlockLinkDTO extends BlockDTO {
+    private final String title;
+    private final String link;
+    private final String image;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockMediaDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockMediaDTO.java
@@ -1,0 +1,11 @@
+package com.smilegate.blog.controller.dto.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BlockMediaDTO extends BlockDTO {
+    private final String title;
+    private final String link;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockProfileDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockProfileDTO.java
@@ -1,0 +1,12 @@
+package com.smilegate.blog.controller.dto.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BlockProfileDTO extends BlockDTO {
+    private final String main;
+    private final String sub;
+    private final String profileImage;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockSNSConnectionDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockSNSConnectionDTO.java
@@ -1,0 +1,11 @@
+package com.smilegate.blog.controller.dto.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BlockSNSConnectionDTO extends BlockDTO {
+    private final String instagram;
+    private final String telephone;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockTextDTO.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/dto/entity/BlockTextDTO.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog.controller.dto.entity;
+
+import com.smilegate.blog.domain.vo.text.TextAlignment;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BlockTextDTO extends BlockDTO {
+    private final String title;
+    private final String content;
+    private final TextAlignment textAlignment;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/mapper/CreatePageResponseMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/mapper/CreatePageResponseMapper.java
@@ -1,0 +1,16 @@
+package com.smilegate.blog.controller.mapper;
+
+import com.smilegate.blog.controller.dto.CreatePageResponseDTO;
+import com.smilegate.blog.service.dto.PageResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreatePageResponseMapper {
+    public static CreatePageResponseDTO create(PageResponse pageResponse) {
+        return new CreatePageResponseDTO(
+                pageResponse.pageId()
+                , pageResponse.page().getName().getText()
+        );
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/controller/mapper/ReadPageResponseMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/controller/mapper/ReadPageResponseMapper.java
@@ -1,0 +1,64 @@
+package com.smilegate.blog.controller.mapper;
+
+import com.smilegate.blog.controller.dto.ReadPageResponseDTO;
+import com.smilegate.blog.controller.dto.entity.BlockLinkDTO;
+import com.smilegate.blog.controller.dto.entity.BlockMediaDTO;
+import com.smilegate.blog.controller.dto.entity.BlockProfileDTO;
+import com.smilegate.blog.controller.dto.entity.BlockSNSConnectionDTO;
+import com.smilegate.blog.controller.dto.entity.BlockTextDTO;
+import com.smilegate.blog.domain.BlockLink;
+import com.smilegate.blog.domain.BlockMedia;
+import com.smilegate.blog.domain.BlockProfile;
+import com.smilegate.blog.domain.BlockSNSConnection;
+import com.smilegate.blog.domain.BlockText;
+import com.smilegate.blog.service.dto.PageResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReadPageResponseMapper {
+    public static ReadPageResponseDTO create(PageResponse pageResponse) {
+        return new ReadPageResponseDTO(
+                pageResponse.pageId()
+                , pageResponse.page().getName().getText()
+                , new BlockProfileDTO(
+                        pageResponse.page().getProfile().getMain().getText()
+                        , pageResponse.page().getProfile().getSub().getText()
+                        , pageResponse.page().getProfile().getProfileImage().link().url()
+                )
+                , pageResponse.page().getBlocks().stream().map(block -> {
+                    if (block instanceof BlockLink object) {
+                        return new BlockLinkDTO(
+                                object.getTitle().getText()
+                                , object.getLink().url()
+                                , object.getImage().link().url()
+                        );
+                    } else if (block instanceof BlockMedia object) {
+                        return new BlockMediaDTO(
+                                object.getTitle().getText()
+                                , object.getLink().url()
+                        );
+                    } else if (block instanceof BlockProfile object) {
+                        return new BlockProfileDTO(
+                                object.getMain().getText()
+                                , object.getSub().getText()
+                                , object.getProfileImage().link().url()
+                        );
+                    } else if (block instanceof BlockSNSConnection object) {
+                        return new BlockSNSConnectionDTO(
+                                object.getInstagram().getText()
+                                , object.getTelephone().getText()
+                        );
+                    } else if (block instanceof BlockText object) {
+                        return new BlockTextDTO(
+                                object.getTitle().getText()
+                                , object.getContent().getText()
+                                , object.getTextAlignment()
+                        );
+                    }
+
+                    throw new IllegalStateException("Unexpected value: " + block);
+                }).toList()
+        );
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/Block.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/Block.java
@@ -1,0 +1,4 @@
+package com.smilegate.blog.domain;
+
+public abstract class Block {
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/BlockLink.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/BlockLink.java
@@ -1,0 +1,15 @@
+package com.smilegate.blog.domain;
+
+import com.smilegate.blog.domain.vo.Image;
+import com.smilegate.blog.domain.vo.Link;
+import com.smilegate.blog.domain.vo.text.TitleBaseText;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public final class BlockLink extends Block {
+    private final TitleBaseText title;
+    private final Link link;
+    private final Image image;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/BlockMedia.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/BlockMedia.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog.domain;
+
+import com.smilegate.blog.domain.vo.Link;
+import com.smilegate.blog.domain.vo.text.TitleBaseText;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public final class BlockMedia extends Block {
+    private final TitleBaseText title;
+    private final Link link;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/BlockProfile.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/BlockProfile.java
@@ -1,0 +1,15 @@
+package com.smilegate.blog.domain;
+
+import com.smilegate.blog.domain.vo.Image;
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+import com.smilegate.blog.domain.vo.text.SubBaseText;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public final class BlockProfile extends Block {
+    private final MainBaseText main;
+    private final SubBaseText sub;
+    private final Image profileImage;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/BlockSNSConnection.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/BlockSNSConnection.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain;
+
+
+import com.smilegate.blog.domain.vo.text.InstagramText;
+import com.smilegate.blog.domain.vo.text.TelephoneBaseText;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public final class BlockSNSConnection extends Block {
+    private final InstagramText instagram;
+    private final TelephoneBaseText telephone;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/BlockText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/BlockText.java
@@ -1,0 +1,15 @@
+package com.smilegate.blog.domain;
+
+import com.smilegate.blog.domain.vo.text.ContentBaseText;
+import com.smilegate.blog.domain.vo.text.TextAlignment;
+import com.smilegate.blog.domain.vo.text.TitleBaseText;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public final class BlockText extends Block {
+    private final TitleBaseText title;
+    private final ContentBaseText content;
+    private final TextAlignment textAlignment;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/BlockType.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/BlockType.java
@@ -1,0 +1,9 @@
+package com.smilegate.blog.domain;
+
+public enum BlockType {
+    PROFILE,
+    LINK,
+    TEXT,
+    MEDIA,
+    SNS_CONNECTION;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/Page.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/Page.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain;
+
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Page {
+    private final MainBaseText name;
+    private final BlockProfile profile;
+    private final List<Block> blocks;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/Image.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/Image.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog.domain.vo;
+
+import java.util.Objects;
+
+public record Image(Link link) {
+    public Image {
+        validateLink(link);
+    }
+
+    private void validateLink(final Link link) {
+        Objects.requireNonNull(link);
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/Link.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/Link.java
@@ -1,0 +1,18 @@
+package com.smilegate.blog.domain.vo;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public record Link(String url) {
+    public Link {
+        validateURLFormat(url);
+    }
+
+    private void validateURLFormat(final String url) {
+        try {
+            new URL(url);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/BaseText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/BaseText.java
@@ -1,0 +1,27 @@
+package com.smilegate.blog.domain.vo.text;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public abstract class BaseText {
+
+    private final String text;
+
+    protected BaseText(final String text) {
+        validateLength(text);
+
+        this.text = text;
+    }
+
+    protected void validateLength(final String text) {
+        Objects.requireNonNull(text);
+
+        final int maxLength = getMaxLength();
+        if (text.length() > maxLength) {
+            throw new IllegalArgumentException(maxLength + " 글자수를 넘길 수 없습니다.");
+        }
+    }
+
+    abstract int getMaxLength();
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/ContentBaseText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/ContentBaseText.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain.vo.text;
+
+public class ContentBaseText extends BaseText {
+    private static final int MAX_LENGTH = 1_000;
+
+    public ContentBaseText(final String text) {
+        super(text);
+    }
+
+    @Override
+    int getMaxLength() {
+        return MAX_LENGTH;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/InstagramText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/InstagramText.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain.vo.text;
+
+public class InstagramText extends BaseText {
+    private static final int MAX_LENGTH = 30;
+
+    public InstagramText(final String text) {
+        super(text);
+    }
+
+    @Override
+    int getMaxLength() {
+        return MAX_LENGTH;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/MainBaseText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/MainBaseText.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain.vo.text;
+
+public class MainBaseText extends BaseText {
+    private static final int MAX_LENGTH = 24;
+
+    public MainBaseText(final String text) {
+        super(text);
+    }
+
+    @Override
+    int getMaxLength() {
+        return MAX_LENGTH;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/SubBaseText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/SubBaseText.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain.vo.text;
+
+public class SubBaseText extends BaseText {
+    private static final int MAX_LENGTH = 1_000;
+
+    public SubBaseText(final String text) {
+        super(text);
+    }
+
+    @Override
+    int getMaxLength() {
+        return MAX_LENGTH;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/TelephoneBaseText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/TelephoneBaseText.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain.vo.text;
+
+public class TelephoneBaseText extends BaseText {
+    private static final int MAX_LENGTH = 60;
+
+    public TelephoneBaseText(final String text) {
+        super(text);
+    }
+
+    @Override
+    int getMaxLength() {
+        return MAX_LENGTH;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/TextAlignment.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/TextAlignment.java
@@ -1,0 +1,7 @@
+package com.smilegate.blog.domain.vo.text;
+
+public enum TextAlignment {
+    LEFT,
+    CENTER,
+    RIGHT;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/TitleBaseText.java
+++ b/blog-api/src/main/java/com/smilegate/blog/domain/vo/text/TitleBaseText.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.domain.vo.text;
+
+public class TitleBaseText extends BaseText {
+    private static final int MAX_LENGTH = 60;
+
+    public TitleBaseText(final String text) {
+        super(text);
+    }
+
+    @Override
+    int getMaxLength() {
+        return MAX_LENGTH;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BaseTimeEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BaseTimeEntity.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog.entity.mongo;
+
+import java.util.Date;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private Date createdAt;
+
+    @LastModifiedDate
+    private Date updatedAt;
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockEntity.java
@@ -1,0 +1,11 @@
+package com.smilegate.blog.entity.mongo;
+
+import org.bson.types.ObjectId;
+
+public abstract class BlockEntity {
+    protected String key;
+
+    protected BlockEntity() {
+        this.key = ObjectId.get().toHexString();
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockLinkEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockLinkEntity.java
@@ -1,0 +1,24 @@
+package com.smilegate.blog.entity.mongo;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.TypeAlias;
+
+@TypeAlias("link")
+@Getter
+@NoArgsConstructor
+public final class BlockLinkEntity extends BlockEntity {
+    private String title;
+    private String link;
+    private String image;
+
+    public BlockLinkEntity(
+            String title
+            , String link
+            , String image
+    ) {
+        this.title = title;
+        this.link = link;
+        this.image = image;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockMediaEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockMediaEntity.java
@@ -1,0 +1,22 @@
+package com.smilegate.blog.entity.mongo;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.TypeAlias;
+
+@TypeAlias("media")
+@Getter
+@NoArgsConstructor
+public final class BlockMediaEntity extends BlockEntity {
+    private String title;
+    private String link;
+
+    public BlockMediaEntity(
+            String title
+            , String link
+    ) {
+        this.title = title;
+        this.link = link;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockProfileEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockProfileEntity.java
@@ -1,0 +1,24 @@
+package com.smilegate.blog.entity.mongo;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.TypeAlias;
+
+@TypeAlias("profile")
+@Getter
+@NoArgsConstructor
+public final class BlockProfileEntity extends BlockEntity {
+    private String main;
+    private String sub;
+    private String image;
+
+    public BlockProfileEntity(
+            String main
+            , String sub
+            , String image
+    ) {
+        this.main = main;
+        this.sub = sub;
+        this.image = image;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockSNSConnectionEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockSNSConnectionEntity.java
@@ -1,0 +1,21 @@
+package com.smilegate.blog.entity.mongo;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.TypeAlias;
+
+@TypeAlias("sns")
+@Getter
+@NoArgsConstructor
+public final class BlockSNSConnectionEntity extends BlockEntity {
+    private String instagram;
+    private String telephone;
+
+    public BlockSNSConnectionEntity(
+            String instagram
+            , String telephone
+    ) {
+        this.instagram = instagram;
+        this.telephone = telephone;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockTextEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/BlockTextEntity.java
@@ -1,0 +1,25 @@
+package com.smilegate.blog.entity.mongo;
+
+import com.smilegate.blog.domain.vo.text.TextAlignment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.TypeAlias;
+
+@TypeAlias("text")
+@Getter
+@NoArgsConstructor
+public final class BlockTextEntity extends BlockEntity {
+    private String title;
+    private String content;
+    private TextAlignment textAlignment;
+
+    public BlockTextEntity(
+            String title
+            , String content
+            , TextAlignment textAlignment
+    ) {
+        this.title = title;
+        this.content = content;
+        this.textAlignment = textAlignment;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/PageEntity.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/PageEntity.java
@@ -1,0 +1,45 @@
+package com.smilegate.blog.entity.mongo;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "pages")
+@Getter
+@NoArgsConstructor
+public final class PageEntity extends BaseTimeEntity {
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    @Field
+    private String name;
+
+    private BlockProfileEntity blockProfile;
+
+    private List<BlockEntity> blocks = new ArrayList<>();
+
+    public PageEntity(final String name) {
+        this.name = name;
+    }
+
+    public PageEntity update(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public PageEntity update(final BlockProfileEntity blockProfile) {
+        this.blockProfile = blockProfile;
+        return this;
+    }
+
+    public PageEntity update(final List<BlockEntity> blocks) {
+        this.blocks = blocks;
+        return this;
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/mapper/BlockEntityMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/mapper/BlockEntityMapper.java
@@ -1,0 +1,65 @@
+package com.smilegate.blog.entity.mongo.mapper;
+
+import com.smilegate.blog.domain.Block;
+import com.smilegate.blog.domain.BlockLink;
+import com.smilegate.blog.domain.BlockMedia;
+import com.smilegate.blog.domain.BlockProfile;
+import com.smilegate.blog.domain.BlockSNSConnection;
+import com.smilegate.blog.domain.BlockText;
+import com.smilegate.blog.entity.mongo.BlockEntity;
+import com.smilegate.blog.entity.mongo.BlockLinkEntity;
+import com.smilegate.blog.entity.mongo.BlockMediaEntity;
+import com.smilegate.blog.entity.mongo.BlockProfileEntity;
+import com.smilegate.blog.entity.mongo.BlockSNSConnectionEntity;
+import com.smilegate.blog.entity.mongo.BlockTextEntity;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BlockEntityMapper {
+    public static List<BlockEntity> create(List<Block> blocks) {
+        if (null == blocks) {
+            return null;
+        }
+
+        return blocks.stream().map(block -> {
+                    if (block instanceof BlockProfile object) {
+                        return new BlockProfileEntity(
+                                object.getMain().getText()
+                                , object.getSub().getText()
+                                , object.getProfileImage().link().url()
+                        );
+                    }
+                    else if (block instanceof BlockLink object) {
+                        return new BlockLinkEntity(
+                                object.getTitle().getText()
+                                , object.getLink().url()
+                                , object.getImage().link().url()
+                        );
+                    }
+                    else if (block instanceof BlockMedia object) {
+                        return new BlockMediaEntity(
+                                object.getTitle().getText()
+                                , object.getLink().url()
+                        );
+                    }
+                    else if (block instanceof BlockSNSConnection object) {
+                        return new BlockSNSConnectionEntity(
+                                object.getInstagram().getText()
+                                , object.getTelephone().getText()
+                        );
+                    }
+                    else if (block instanceof BlockText object) {
+                        return new BlockTextEntity(
+                                object.getTitle().getText()
+                                , object.getContent().getText()
+                                , object.getTextAlignment()
+                        );
+                    }
+
+                    throw new IllegalStateException("Unexpected value: " + block);
+                }
+        ).toList();
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/mapper/BlockProfileEntityMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/mapper/BlockProfileEntityMapper.java
@@ -1,0 +1,21 @@
+package com.smilegate.blog.entity.mongo.mapper;
+
+import com.smilegate.blog.domain.BlockProfile;
+import com.smilegate.blog.entity.mongo.BlockProfileEntity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BlockProfileEntityMapper {
+    public static BlockProfileEntity create(BlockProfile profile) {
+        if (null == profile) {
+            return null;
+        }
+
+        return new BlockProfileEntity(
+                profile.getMain().getText()
+                , profile.getSub().getText()
+                , profile.getProfileImage().link().url()
+        );
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/entity/mongo/mapper/PageEntityMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/entity/mongo/mapper/PageEntityMapper.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog.entity.mongo.mapper;
+
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+import com.smilegate.blog.entity.mongo.PageEntity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageEntityMapper {
+    public static PageEntity create(MainBaseText name) {
+        return new PageEntity(name.getText());
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/repository/PageRepository.java
+++ b/blog-api/src/main/java/com/smilegate/blog/repository/PageRepository.java
@@ -1,0 +1,10 @@
+package com.smilegate.blog.repository;
+
+import com.smilegate.blog.entity.mongo.PageEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface PageRepository extends MongoRepository<PageEntity, String> {
+}

--- a/blog-api/src/main/java/com/smilegate/blog/service/PageService.java
+++ b/blog-api/src/main/java/com/smilegate/blog/service/PageService.java
@@ -1,0 +1,55 @@
+package com.smilegate.blog.service;
+
+import com.smilegate.blog.controller.dto.CreatePageResponseDTO;
+import com.smilegate.blog.entity.mongo.PageEntity;
+import com.smilegate.blog.entity.mongo.mapper.BlockEntityMapper;
+import com.smilegate.blog.entity.mongo.mapper.BlockProfileEntityMapper;
+import com.smilegate.blog.entity.mongo.mapper.PageEntityMapper;
+import com.smilegate.blog.repository.PageRepository;
+import com.smilegate.blog.service.dto.CreatePageRequest;
+import com.smilegate.blog.service.dto.PageResponse;
+import com.smilegate.blog.service.dto.UpdatePageRequest;
+import com.smilegate.blog.service.mapper.PageResponseMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PageService {
+    private final PageRepository repository;
+
+    @Transactional
+    public PageResponse createPage(CreatePageRequest request) {
+        PageEntity pageEntity = PageEntityMapper.create(request.name());
+        repository.save(pageEntity);
+
+        return PageResponseMapper.create(pageEntity);
+    }
+
+    public PageResponse readPage(String pageId) {
+        PageEntity pageEntity = repository.findById(pageId).orElseThrow();
+
+        return PageResponseMapper.create(pageEntity);
+    }
+
+    @Transactional
+    public PageResponse updatePage(UpdatePageRequest request) {
+        PageEntity pageEntity = repository.findById(request.pageId()).orElseThrow();
+
+        pageEntity.update(BlockProfileEntityMapper.create(request.profile()));
+        pageEntity.update(BlockEntityMapper.create(request.blocks()));
+        repository.save(pageEntity);
+
+        return PageResponseMapper.create(pageEntity);
+    }
+
+    @Transactional
+    public PageResponse deletePage(String pageId) {
+        PageEntity pageEntity = repository.findById(pageId).orElseThrow();
+        repository.delete(pageEntity);
+
+        return PageResponseMapper.create(pageEntity);
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/service/dto/CreatePageRequest.java
+++ b/blog-api/src/main/java/com/smilegate/blog/service/dto/CreatePageRequest.java
@@ -1,0 +1,6 @@
+package com.smilegate.blog.service.dto;
+
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+
+public record CreatePageRequest(MainBaseText name) {
+}

--- a/blog-api/src/main/java/com/smilegate/blog/service/dto/PageResponse.java
+++ b/blog-api/src/main/java/com/smilegate/blog/service/dto/PageResponse.java
@@ -1,0 +1,9 @@
+package com.smilegate.blog.service.dto;
+
+import com.smilegate.blog.domain.Page;
+
+public record PageResponse(
+        String pageId
+        , Page page
+) {
+}

--- a/blog-api/src/main/java/com/smilegate/blog/service/dto/UpdatePageRequest.java
+++ b/blog-api/src/main/java/com/smilegate/blog/service/dto/UpdatePageRequest.java
@@ -1,0 +1,14 @@
+package com.smilegate.blog.service.dto;
+
+import com.smilegate.blog.domain.Block;
+import com.smilegate.blog.domain.BlockProfile;
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+import java.util.List;
+
+public record UpdatePageRequest(
+        String pageId
+        , MainBaseText name
+        , BlockProfile profile
+        , List<Block> blocks
+) {
+}

--- a/blog-api/src/main/java/com/smilegate/blog/service/mapper/CreatePageRequestMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/service/mapper/CreatePageRequestMapper.java
@@ -1,0 +1,15 @@
+package com.smilegate.blog.service.mapper;
+
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+import com.smilegate.blog.service.dto.CreatePageRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreatePageRequestMapper {
+    public static CreatePageRequest create(String name) {
+        return new CreatePageRequest(
+                new MainBaseText(name)
+        );
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/service/mapper/PageResponseMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/service/mapper/PageResponseMapper.java
@@ -1,0 +1,102 @@
+package com.smilegate.blog.service.mapper;
+
+import com.smilegate.blog.domain.Block;
+import com.smilegate.blog.domain.BlockLink;
+import com.smilegate.blog.domain.BlockMedia;
+import com.smilegate.blog.domain.BlockProfile;
+import com.smilegate.blog.domain.BlockSNSConnection;
+import com.smilegate.blog.domain.BlockText;
+import com.smilegate.blog.domain.Page;
+import com.smilegate.blog.domain.vo.Image;
+import com.smilegate.blog.domain.vo.Link;
+import com.smilegate.blog.domain.vo.text.ContentBaseText;
+import com.smilegate.blog.domain.vo.text.InstagramText;
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+import com.smilegate.blog.domain.vo.text.SubBaseText;
+import com.smilegate.blog.domain.vo.text.TelephoneBaseText;
+import com.smilegate.blog.domain.vo.text.TitleBaseText;
+import com.smilegate.blog.entity.mongo.BlockEntity;
+import com.smilegate.blog.entity.mongo.BlockLinkEntity;
+import com.smilegate.blog.entity.mongo.BlockMediaEntity;
+import com.smilegate.blog.entity.mongo.BlockProfileEntity;
+import com.smilegate.blog.entity.mongo.BlockSNSConnectionEntity;
+import com.smilegate.blog.entity.mongo.BlockTextEntity;
+import com.smilegate.blog.entity.mongo.PageEntity;
+import com.smilegate.blog.service.dto.PageResponse;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageResponseMapper {
+    public static PageResponse create(PageEntity pageEntity) {
+        Page page = new Page(
+                new MainBaseText(pageEntity.getName())
+                , getBlockProfile(pageEntity.getBlockProfile())
+                , getBlocks(pageEntity.getBlocks())
+        );
+
+        return new PageResponse(
+                pageEntity.getId()
+                , page
+        );
+    }
+
+    private static BlockProfile getBlockProfile(BlockProfileEntity profileEntity) {
+        if (profileEntity == null) {
+            return null;
+        }
+
+        return new BlockProfile(
+                new MainBaseText(profileEntity.getMain())
+                , new SubBaseText(profileEntity.getSub())
+                , new Image(new Link(profileEntity.getImage()))
+        );
+    }
+
+    private static List<Block> getBlocks(List<BlockEntity> blockEntities) {
+        if (blockEntities == null) {
+            return List.of();
+        }
+
+        if (blockEntities.isEmpty()) {
+            return List.of();
+        }
+
+        return blockEntities.stream().map(blockEntity ->
+                {
+                    if (blockEntity instanceof BlockProfileEntity object) {
+                        return new BlockProfile(
+                                new MainBaseText(object.getMain())
+                                , new SubBaseText(object.getSub())
+                                , new Image(new Link(object.getImage()))
+                        );
+                    } else if (blockEntity instanceof BlockLinkEntity object) {
+                        return new BlockLink(
+                                new TitleBaseText(object.getTitle())
+                                , new Link(object.getLink())
+                                , new Image(new Link(object.getImage()))
+                        );
+                    } else if (blockEntity instanceof BlockMediaEntity object) {
+                        return new BlockMedia(
+                                new TitleBaseText(object.getTitle())
+                                , new Link(object.getLink())
+                        );
+                    } else if (blockEntity instanceof BlockSNSConnectionEntity object) {
+                        return new BlockSNSConnection(
+                                new InstagramText(object.getInstagram())
+                                , new TelephoneBaseText(object.getTelephone())
+                        );
+                    } else if (blockEntity instanceof BlockTextEntity object) {
+                        return new BlockText(
+                                new TitleBaseText(object.getTitle())
+                                , new ContentBaseText(object.getContent())
+                                , object.getTextAlignment()
+                        );
+                    }
+
+                    throw new IllegalStateException("Unexpected value: " + blockEntity);
+                }
+        ).toList();
+    }
+}

--- a/blog-api/src/main/java/com/smilegate/blog/service/mapper/UpdatePageRequestMapper.java
+++ b/blog-api/src/main/java/com/smilegate/blog/service/mapper/UpdatePageRequestMapper.java
@@ -1,0 +1,79 @@
+package com.smilegate.blog.service.mapper;
+
+import com.smilegate.blog.domain.BlockLink;
+import com.smilegate.blog.domain.BlockMedia;
+import com.smilegate.blog.domain.BlockProfile;
+import com.smilegate.blog.domain.BlockSNSConnection;
+import com.smilegate.blog.domain.BlockText;
+import com.smilegate.blog.domain.vo.Image;
+import com.smilegate.blog.domain.vo.Link;
+import com.smilegate.blog.domain.vo.text.ContentBaseText;
+import com.smilegate.blog.domain.vo.text.InstagramText;
+import com.smilegate.blog.domain.vo.text.MainBaseText;
+import com.smilegate.blog.domain.vo.text.SubBaseText;
+import com.smilegate.blog.domain.vo.text.TelephoneBaseText;
+import com.smilegate.blog.domain.vo.text.TitleBaseText;
+import com.smilegate.blog.controller.dto.entity.BlockDTO;
+import com.smilegate.blog.controller.dto.entity.BlockLinkDTO;
+import com.smilegate.blog.controller.dto.entity.BlockMediaDTO;
+import com.smilegate.blog.controller.dto.entity.BlockProfileDTO;
+import com.smilegate.blog.controller.dto.entity.BlockSNSConnectionDTO;
+import com.smilegate.blog.controller.dto.entity.BlockTextDTO;
+import com.smilegate.blog.service.dto.UpdatePageRequest;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdatePageRequestMapper {
+    public static UpdatePageRequest create(
+            String id
+            , String name
+            , BlockProfileDTO profile
+            , List<BlockDTO> blocks
+    ) {
+        return new UpdatePageRequest(
+                id
+                , new MainBaseText(name)
+                , new BlockProfile(
+                new MainBaseText(profile.getMain())
+                , new SubBaseText(profile.getSub())
+                , new Image(new Link(profile.getProfileImage()))
+        )
+                , blocks.stream().map(blockDTO -> {
+                    if (blockDTO instanceof BlockProfileDTO object) {
+                        return new BlockProfile(
+                                new MainBaseText(object.getMain())
+                                , new SubBaseText(object.getSub())
+                                , new Image(new Link(object.getProfileImage()))
+                        );
+                    } else if (blockDTO instanceof BlockLinkDTO object) {
+                        return new BlockLink(
+                                new TitleBaseText(object.getTitle())
+                                , new Link(object.getLink())
+                                , new Image(new Link(object.getImage()))
+                        );
+                    } else if (blockDTO instanceof BlockMediaDTO object) {
+                        return new BlockMedia(
+                                new TitleBaseText(object.getTitle())
+                                , new Link(object.getLink())
+                        );
+                    } else if (blockDTO instanceof BlockSNSConnectionDTO object) {
+                        return new BlockSNSConnection(
+                                new InstagramText(object.getInstagram())
+                                , new TelephoneBaseText(object.getTelephone())
+                        );
+                    } else if (blockDTO instanceof BlockTextDTO object) {
+                        return new BlockText(
+                                new TitleBaseText(object.getTitle())
+                                , new ContentBaseText(object.getContent())
+                                , object.getTextAlignment()
+                        );
+                    }
+
+                    throw new IllegalStateException("Unexpected value: " + blockDTO);
+                }
+        ).toList()
+        );
+    }
+}

--- a/blog-api/src/main/resources/application.yml
+++ b/blog-api/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+server:
+    port: 8200
+
+spring:
+  data:
+    mongodb:
+      uri: mongodb://chipmunk:JMTpdsu8YkLEXBW4RA@localhost:27017/blog

--- a/blog-api/src/test/java/com/smilegate/blog/BlogApplicationTest.java
+++ b/blog-api/src/test/java/com/smilegate/blog/BlogApplicationTest.java
@@ -1,0 +1,13 @@
+package com.smilegate.blog;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BlogApplicationTest {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/blog-api/src/test/java/com/smilegate/blog/MongoDBTest.java
+++ b/blog-api/src/test/java/com/smilegate/blog/MongoDBTest.java
@@ -1,0 +1,88 @@
+package com.smilegate.blog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.client.model.Filters;
+import com.smilegate.blog.entity.mongo.BlockLinkEntity;
+import com.smilegate.blog.entity.mongo.BlockProfileEntity;
+import com.smilegate.blog.entity.mongo.BlockTextEntity;
+import com.smilegate.blog.entity.mongo.PageEntity;
+import com.smilegate.blog.repository.PageRepository;
+import com.smilegate.blog.domain.vo.text.TextAlignment;
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import util.MongoContainers;
+
+@Testcontainers
+@DataMongoTest
+public class MongoDBTest {
+
+    @Container
+    private static MongoDBContainer mongoDBContainer = MongoContainers.getDefaultContainer();
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+    }
+
+    @Autowired MongoOperations operations;
+    @Autowired PageRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        operations.remove(PageEntity.class).all();
+    }
+
+    @Test
+    void insertTest() {
+        PageEntity page = new PageEntity("name");
+
+        BlockProfileEntity profile = new BlockProfileEntity(
+                "main"
+                , "sub"
+                , "https://www.naver.com"
+        );
+
+        page.update(
+                new BlockProfileEntity(
+                        "main"
+                        , "sub"
+                        , "https://www.naver.com"
+                )
+            )
+            .update(
+                    List.of(
+                        new BlockTextEntity(
+                                "title"
+                                , "sub"
+                                , TextAlignment.CENTER
+                        ),
+                        new BlockLinkEntity(
+                            "title",
+                                "link",
+                                "https://www.naver.com"
+                        )
+                    )
+            );
+        PageEntity savedPage = repository.save(page);
+
+        System.out.println(savedPage.getId());
+
+        Document stored = operations.execute(PageEntity.class, collection ->
+            collection.find(Filters.eq("_id",savedPage.getId())).first()
+        );
+
+        assertThat(stored).containsAllEntriesOf(new Document("_id", savedPage.getId()));
+    }
+}

--- a/blog-api/src/test/java/util/MongoContainers.java
+++ b/blog-api/src/test/java/util/MongoContainers.java
@@ -1,0 +1,15 @@
+package util;
+
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class MongoContainers {
+
+	private static final String IMAGE_NAME = "mongo:5.0";
+	private static final String IMAGE_NAME_PROPERTY = "mongo.default.image.name";
+
+	public static MongoDBContainer getDefaultContainer() {
+		return new MongoDBContainer(DockerImageName.parse(System.getProperty(IMAGE_NAME_PROPERTY, IMAGE_NAME)))
+				.withReuse(true);
+	}
+}

--- a/blog-api/src/test/resources/application.yml
+++ b/blog-api/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+server:
+    port: 8200
+
+spring:
+  data:
+    mongodb:
+      uri: mongodb://chipmunk:JMTpdsu8YkLEXBW4RA@localhost:27017/blog

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,5 @@ rootProject.name = 'profile-link-service'
 
 include "url-shortner-api"
 include 'ticket-api'
+include 'blog-api'
+

--- a/ticket-api/src/main/java/com/smilegate/ticket/entity/Ticket.java
+++ b/ticket-api/src/main/java/com/smilegate/ticket/entity/Ticket.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,9 +13,10 @@ import lombok.NoArgsConstructor;
 @Table
 @NoArgsConstructor
 @Getter
+@SequenceGenerator(name = "ticket_seq", initialValue = 1_000_000)
 public class Ticket extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "ticket_seq")
     private Long id;
 
     public Ticket(Long id) {

--- a/ticket-api/src/main/resources/application.yml
+++ b/ticket-api/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-    port: 8001
+    port: 8100
 
 spring:
   datasource:

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/controller/RedirectionController.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/controller/RedirectionController.java
@@ -3,6 +3,10 @@ package com.smilegate.urlshortner.controller;
 import com.smilegate.urlshortner.dto.ShortURLDTO;
 import com.smilegate.urlshortner.service.RedirectionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,13 +17,23 @@ import org.springframework.web.servlet.view.RedirectView;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/")
+@Slf4j
 public class RedirectionController {
+    private final Logger logger = LoggerFactory.getLogger(RedirectionController.class);
+
     private final RedirectionService redirectionService;
+    private final Environment environment;
 
     @GetMapping("{id}")
     public RedirectView redirectOriginURL(@PathVariable("id") String shortUrl) {
-        final ShortURLDTO shortURLDTO = redirectionService.getShortURLByShortUrl(shortUrl);
-        final String originURL = shortURLDTO.originUrl();
+        String originURL = environment.getProperty("redirect.web.baseurl");
+
+        try {
+            final ShortURLDTO shortURLDTO = redirectionService.getShortURLByShortUrl(shortUrl);
+            originURL = shortURLDTO.originUrl();
+        } catch (RuntimeException exception) {
+            logger.warn(String.format("찾을 수 없는 단축 주소를 요청했습니다. - %s", shortUrl));
+        }
 
         final RedirectView redirectView = new RedirectView(originURL);
         redirectView.setStatusCode(HttpStatus.PERMANENT_REDIRECT);

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/entity/ShortURL.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/entity/ShortURL.java
@@ -22,11 +22,19 @@ public class ShortURL extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String originUrl;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String shortUrl;
 
-    public ShortURL(final String originUrl, final String shortUrl) {
+    @Column(nullable = false, unique = true)
+    private Long ticket;
+
+    public ShortURL(
+            final String originUrl
+            , final String shortUrl
+            , final Long ticket
+    ) {
         this.originUrl = originUrl;
         this.shortUrl = shortUrl;
+        this.ticket = ticket;
     }
 }

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/repository/ShortURLRepository.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/repository/ShortURLRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShortURLRepository extends JpaRepository<ShortURL, Long> {
     Optional<ShortURL> findByOriginUrl(String originUrl);
-    Optional<ShortURL> findByShortUrl(String shortUrl);
-
-    Optional<ShortURL> findTopByOrderByIdDesc();
+    Optional<ShortURL> findByTicket(Long ticket);
 }
+

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/RedirectionService.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/RedirectionService.java
@@ -3,7 +3,9 @@ package com.smilegate.urlshortner.service;
 import com.smilegate.urlshortner.dto.ShortURLDTO;
 import com.smilegate.urlshortner.entity.ShortURL;
 import com.smilegate.urlshortner.repository.ShortURLRepository;
+import com.smilegate.urlshortner.util.Base62Util;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,9 +16,9 @@ public class RedirectionService {
     private final ShortURLRepository shortURLRepository;
 
     public ShortURLDTO getShortURLByShortUrl(final String shortUrl) {
-        final ShortURL shortURL = shortURLRepository.findByShortUrl(shortUrl)
+        final Long originalId = Base62Util.decode(shortUrl);
+        final ShortURL shortURL = shortURLRepository.findByTicket(originalId)
                 .orElseThrow();
-
         return ShortURLDTO.from(shortURL);
     }
 }

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/ShortURLService.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/ShortURLService.java
@@ -32,7 +32,11 @@ public class ShortURLService {
         final TicketIssueResponseDTO ticketResponseDTO = ticketService.issue();
         final long issueId = ticketResponseDTO.issueId();
 
-        final ShortURL shortURLEntity = new ShortURL(request.originUrl(), Base62Util.from(issueId));
+        final ShortURL shortURLEntity = new ShortURL(
+                request.originUrl()
+                , Base62Util.encode(issueId)
+                , issueId
+        );
         final ShortURL createdShortURL = shortURLRepository.save(shortURLEntity);
 
         return CreateShortURLResponseDTO.from(createdShortURL);

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/ShortURLService.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/ShortURLService.java
@@ -21,7 +21,7 @@ public class ShortURLService {
 
     @Transactional
     public CreateShortURLResponseDTO getOrCreateShortURL(final CreateShortURLRequestDTO request) {
-        final String originURL = removedTrailSlash(request.originUrl());
+        final String originURL = removeTrailSlash(request.originUrl());
         validateOriginURL(originURL);
 
         final Optional<ShortURL> retrievalShortURL = shortURLRepository.findByOriginUrl(originURL);
@@ -38,7 +38,7 @@ public class ShortURLService {
         return CreateShortURLResponseDTO.from(createdShortURL);
     }
 
-    private String removedTrailSlash(final String originURL) {
+    private String removeTrailSlash(final String originURL) {
         if (originURL.endsWith("/")) {
             return originURL.substring(0, originURL.length() - 1);
         }

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/TicketService.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/service/TicketService.java
@@ -1,7 +1,6 @@
 package com.smilegate.urlshortner.service;
 
 import com.smilegate.urlshortner.dto.TicketIssueResponseDTO;
-import java.time.Duration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/util/Base62Util.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/util/Base62Util.java
@@ -20,7 +20,7 @@ public class Base62Util {
     }
 
     public static String from(long id) {
-        StringBuilder builder = new StringBuilder(MAX_LENGTH);
+        final StringBuilder builder = new StringBuilder(MAX_LENGTH);
 
         while (id > 0) {
             builder.append(SCHEMES[(int) (id % RADIX)]);

--- a/url-shortner-api/src/main/java/com/smilegate/urlshortner/util/Base62Util.java
+++ b/url-shortner-api/src/main/java/com/smilegate/urlshortner/util/Base62Util.java
@@ -1,5 +1,10 @@
 package com.smilegate.urlshortner.util;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 public class Base62Util {
 
     private static final int MAX_LENGTH = 8;
@@ -15,11 +20,18 @@ public class Base62Util {
             'A', 's'
     };
 
+    private static final Map<Character, Integer> DECODE_SCHEMES = new HashMap<>();
+    static {
+        for (int idx = 0; idx < SCHEMES.length; idx++) {
+            DECODE_SCHEMES.put(SCHEMES[idx], idx);
+        }
+    }
+
     private Base62Util() {
         // No Instances
     }
 
-    public static String from(long id) {
+    public static String encode(long id) {
         final StringBuilder builder = new StringBuilder(MAX_LENGTH);
 
         while (id > 0) {
@@ -28,5 +40,27 @@ public class Base62Util {
         }
 
         return builder.toString();
+    }
+
+    public static long decode(String encrypted) {
+        validateEncrypted(encrypted);
+
+        long decrypted = 0;
+        int pow = 0;
+
+        for (char scheme : encrypted.toCharArray()) {
+            int schemeIndex = DECODE_SCHEMES.get(scheme);
+            decrypted += (long) (Math.pow(RADIX, pow) * schemeIndex);
+            pow++;
+        }
+
+        return decrypted;
+    }
+
+    private static void validateEncrypted(String encrypted) {
+        Objects.requireNonNull(encrypted);
+        if (encrypted.isBlank()) {
+            throw new IllegalArgumentException("빈 값을 복호화할 수 없습니다.");
+        }
     }
 }

--- a/url-shortner-api/src/main/resources/application.yml
+++ b/url-shortner-api/src/main/resources/application.yml
@@ -25,3 +25,7 @@ spring:
 webclient:
   ticket:
     baseurl: http://localhost:8100
+
+redirect:
+  web:
+    baseurl: http://localhost:3000

--- a/url-shortner-api/src/main/resources/application.yml
+++ b/url-shortner-api/src/main/resources/application.yml
@@ -24,4 +24,4 @@ spring:
 
 webclient:
   ticket:
-    baseurl: http://localhost:8001
+    baseurl: http://localhost:8100

--- a/url-shortner-api/src/test/java/com/smilegate/urlshortner/service/RedirectionServiceTest.java
+++ b/url-shortner-api/src/test/java/com/smilegate/urlshortner/service/RedirectionServiceTest.java
@@ -30,10 +30,10 @@ class RedirectionServiceTest {
     void Should_Get_Short_URL_When_Short_URL_Serve() {
         //given
         final String originURL = "https://www.naver.com";
-        final String shortURL = Base62Util.from(1L);
+        final String shortURL = Base62Util.encode(1L);
 
-        final ShortURL expectedShortURL = new ShortURL(originURL, shortURL);
-        when(shortURLRepository.findByShortUrl(any())).thenReturn(Optional.of(expectedShortURL));
+        final ShortURL expectedShortURL = new ShortURL(originURL, shortURL, 1L);
+        when(shortURLRepository.findByTicket(any())).thenReturn(Optional.of(expectedShortURL));
 
         final ShortURLDTO expected = ShortURLDTO.from(expectedShortURL);
 
@@ -49,9 +49,9 @@ class RedirectionServiceTest {
     void Should_Throw_Exception_When_Short_Url_Not_Found() {
         //given
         final String originURL = "https://www.naver.com";
-        final String shortURL = Base62Util.from(1L);
+        final String shortURL = Base62Util.encode(1L);
 
-        final ShortURL expectedShortURL = new ShortURL(originURL, shortURL);
+        final ShortURL expectedShortURL = new ShortURL(originURL, shortURL, 1L);
 
         //when,then
         assertThatThrownBy(() -> redirectionService.getShortURLByShortUrl(shortURL));

--- a/url-shortner-api/src/test/java/com/smilegate/urlshortner/service/ShortURLServiceTest.java
+++ b/url-shortner-api/src/test/java/com/smilegate/urlshortner/service/ShortURLServiceTest.java
@@ -36,7 +36,7 @@ class ShortURLServiceTest {
         final String originURL = "https://www.naver.com";
         final CreateShortURLRequestDTO request = new CreateShortURLRequestDTO(originURL);
 
-        final ShortURL expectedShortURL = new ShortURL(originURL, Base62Util.from(1L));
+        final ShortURL expectedShortURL = new ShortURL(originURL, Base62Util.encode(1L), 1L);
 
         final CreateShortURLResponseDTO expected = CreateShortURLResponseDTO.from(expectedShortURL);
 
@@ -58,7 +58,7 @@ class ShortURLServiceTest {
         final String originURL = "https://www.naver.com";
         final CreateShortURLRequestDTO request = new CreateShortURLRequestDTO(originURL);
 
-        final ShortURL expectedShortURL = new ShortURL(originURL, Base62Util.from(1L));
+        final ShortURL expectedShortURL = new ShortURL(originURL, Base62Util.encode(1L), 1L);
 
         final CreateShortURLResponseDTO expected = CreateShortURLResponseDTO.from(expectedShortURL);
 
@@ -79,7 +79,7 @@ class ShortURLServiceTest {
         final CreateShortURLRequestDTO request = new CreateShortURLRequestDTO(originURLWithSlash);
 
         final String originURLWithoutSlash = "https://www.naver.com";
-        final ShortURL expectedShortURL = new ShortURL(originURLWithoutSlash, Base62Util.from(1L));
+        final ShortURL expectedShortURL = new ShortURL(originURLWithoutSlash, Base62Util.encode(1L), 1L);
 
         final CreateShortURLResponseDTO expected = CreateShortURLResponseDTO.from(expectedShortURL);
 

--- a/url-shortner-api/src/test/java/com/smilegate/urlshortner/util/Base62UtilTest.java
+++ b/url-shortner-api/src/test/java/com/smilegate/urlshortner/util/Base62UtilTest.java
@@ -13,7 +13,19 @@ class Base62UtilTest {
     void Should_Base62_Encryption_When_Id_Serve(long id, String expected) {
         //given
         //when
-        final String actual = Base62Util.from(id);
+        final String actual = Base62Util.encode(id);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"H:10" , "jVo:100000", "uRpwN:100000000"}, delimiter = ':')
+    @DisplayName("62진법으로 고유 번호를 문자열로 변환합니다.")
+    void Should_Base62_Decryption_When_Id_Serve(String encrypted, long expected) {
+        //given
+        //when
+        final Long actual = Base62Util.decode(encrypted);
 
         //then
         assertThat(actual).isEqualTo(expected);


### PR DESCRIPTION
## 요약
프로필 링크 페이지를 관리하는 서버입니다.
블럭들을 만들고, 수정하고, 삭제합니다.
한 페이지에 프로필 블럭, 텍스트 블럭, 미디어 블럭, 링크 블럭, SNS 블럭을 편집합니다.

URL 단축 서버에 티켓 번호를 같이 저장합니다.
이후 빠른 성능을 위해 조회 시 단축 주소를 복호화한 티켓 번호로 조회합니다.
단축 주소를 찾지 못한 경우 경고 로그를 출력하고 기본 홈페이지로 이동합니다.

## API 서버 설명
- `Blog Server` : [블로그 서버 README.md](https://github.com/kor-Chipmunk/ProfileLinkService/blob/step4/blog-simple/blog-api/README.md) 파일에 클래스 다이어그램과 함께 문서를 작성했습니다.
